### PR TITLE
New brand

### DIFF
--- a/source/includes/_pricing.md
+++ b/source/includes/_pricing.md
@@ -70,7 +70,7 @@ The _unit_ attribute defines the plan and options for that are fixed unless exte
 | **On Request** | Access to data product is given only on request. Often provider expects customer to meet provider first. In the discussions conditions, pricing etc are agreed. |
 
 
-## Optional attributes and elements
+## Pricing Plans optional attributes and elements
 
 > Example of Pricing component usage in english:
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -379,7 +379,7 @@ html, body {
     padding-top: 1.2em;
     padding-bottom: 1.2em;
     background-color: transparent;
-    margin-right: 1px;
+    // margin-right: 1px;
 
   }
 


### PR DESCRIPTION
Styling of H2 not to extend to examples column. Also fixed anchor link in Pricing plans pointing to optional attributes